### PR TITLE
feat(): add rule to catch boolean props that will lead to boolean attributes that are not HTML5-compliant

### DIFF
--- a/docs/strict-boolean-attributes.md
+++ b/docs/strict-boolean-attributes.md
@@ -1,0 +1,13 @@
+# strict-boolean-attributes
+
+This rule will catch any Stencil Props that would produce boolean attributes that are not [HTML5-compliant](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes). 
+
+## Config
+
+No config is needed
+
+## Usage
+
+```json
+{ "@stencil/strict-boolean-attributes": "error" }
+```

--- a/src/rules/strict-boolean-attributes.ts
+++ b/src/rules/strict-boolean-attributes.ts
@@ -1,10 +1,10 @@
 import { Rule } from 'eslint';
-import { getDecorator, parseDecorator, stencilComponentContext } from '../utils';
+import { getDecorator, stencilComponentContext } from '../utils';
 
 const rule: Rule.RuleModule = {
     meta: {
         docs: {
-            description: 'This rule will catch any Stencil boolean Props that would not be able to be set to false with plain HTML5.',
+            description: 'This rule catches Stencil boolean Props that would not be able to be set to false with HTML5-compliant attributes.',
             category: 'Possible Errors',
             recommended: false
         },
@@ -20,16 +20,11 @@ const rule: Rule.RuleModule = {
             'ClassProperty': (node: any) => {
                 const propDecorator = getDecorator(node, 'Prop');
                 if (stencil.isComponent() && propDecorator) {
-                    const [opts] = parseDecorator(propDecorator);
-                    if (opts?.reflected === false) {
-                        return;
-                    }
-
                     const initializer = node.value.value;
                     if (initializer === true) {
                         context.report({
                             node: node.key,
-                            message: `Boolean properties decorated with @Prop() that are reflected should not be initialized to true`
+                            message: `Boolean properties decorated with @Prop() should not be initialized to true`
                         });
                     }
                 }

--- a/src/rules/strict-boolean-attributes.ts
+++ b/src/rules/strict-boolean-attributes.ts
@@ -1,0 +1,41 @@
+import { Rule } from 'eslint';
+import { getDecorator, parseDecorator, stencilComponentContext } from '../utils';
+
+const rule: Rule.RuleModule = {
+    meta: {
+        docs: {
+            description: 'This rule will catch any Stencil boolean Props that would not be able to be set to false with plain HTML5.',
+            category: 'Possible Errors',
+            recommended: false
+        },
+        schema: [],
+        type: 'problem'
+    },
+
+    create(context): Rule.RuleListener {
+        const stencil = stencilComponentContext();
+
+        return {
+            ...stencil.rules,
+            'ClassProperty': (node: any) => {
+                const propDecorator = getDecorator(node, 'Prop');
+                if (stencil.isComponent() && propDecorator) {
+                    const [opts] = parseDecorator(propDecorator);
+                    if (opts?.reflected === false) {
+                        return;
+                    }
+
+                    const initializer = node.value.value;
+                    if (initializer === true) {
+                        context.report({
+                            node: node.key,
+                            message: `Boolean properties decorated with @Prop() that are reflected should not be initialized to true`
+                        });
+                    }
+                }
+            }
+        };
+    }
+};
+
+export default rule;

--- a/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.good.tsx
+++ b/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.good.tsx
@@ -1,0 +1,8 @@
+@Component({ tag: 'sample-tag' })
+export class SampleTag {
+    @Prop({ reflect: true }) aBoolean = false;
+
+    render() {
+        return (<div>test</div>);
+    }
+}

--- a/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.good.tsx
+++ b/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.good.tsx
@@ -1,6 +1,6 @@
 @Component({ tag: 'sample-tag' })
 export class SampleTag {
-    @Prop({ reflect: true }) aBoolean = false;
+    @Prop() aBoolean = false;
 
     render() {
         return (<div>test</div>);

--- a/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.spec.ts
+++ b/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.spec.ts
@@ -1,0 +1,27 @@
+import rule from '../../../../src/rules/strict-boolean-attributes';
+import { ruleTester } from '../rule-tester';
+import * as path from 'path';
+import * as fs from 'fs';
+
+describe('stencil rules', () => {
+    const files = {
+        good: path.resolve(__dirname, 'strict-boolean-attributes.good.tsx'),
+        wrong: path.resolve(__dirname, 'strict-boolean-attributes.wrong.tsx')
+    };
+    ruleTester.run('strict-boolean-attributes', rule, {
+        valid: [
+            {
+                code: fs.readFileSync(files.good, 'utf8'),
+                filename: files.good
+            }
+        ],
+
+        invalid: [
+            {
+                code: fs.readFileSync(files.wrong, 'utf8'),
+                filename: files.wrong,
+                errors: 1
+            }
+        ]
+    });
+});

--- a/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.wrong.tsx
+++ b/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.wrong.tsx
@@ -1,0 +1,8 @@
+@Component({ tag: 'sample-tag' })
+export class SampleTag {
+    @Prop({ reflect: true }) aBoolean = true;
+
+    render() {
+        return (<div>test</div>);
+    }
+}

--- a/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.wrong.tsx
+++ b/tests/lib/rules/strict-boolean-attributes/strict-boolean-attributes.wrong.tsx
@@ -1,6 +1,6 @@
 @Component({ tag: 'sample-tag' })
 export class SampleTag {
-    @Prop({ reflect: true }) aBoolean = true;
+    @Prop() aBoolean = true;
 
     render() {
         return (<div>test</div>);


### PR DESCRIPTION
This rule will prevents cases where a component's boolean prop can't be initially set to false with plain HTML5.

For example, assuming the following component,

```tsx
@Component({ tag: 'my-component' })
export class MyComponent {
    @Prop() someBoolean = true;

    render() { /* ... */ }
}
```

The following snippets would be equivalent after the component initializes.

```html
<my-component some-boolean></my-component>
```

```html
<my-component></my-component>
```