### PR TITLE
Ban default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ npm run lint
 
 This rule catches Stencil public methods that are not async.
 
+- [`@stencil-community/ban-default-true`](./docs/ban-default-true.md)
+
+This rule catches Stencil Props with a default value of `true`.
+
 - [`@stencil-community/ban-prefix`](./docs/ban-prefix.md)
 
 This rule catches Stencil Component banned tag name prefix.

--- a/docs/ban-default-true.md
+++ b/docs/ban-default-true.md
@@ -1,0 +1,16 @@
+# ban-default-true
+
+In HTML, [boolean attributes always have a default value of `false`](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes). This ensures that Stencil props behave the same way.
+
+## Config
+
+No config is needed
+
+## Usage
+
+```json
+{ "@stencil-community/ban-default-true": "error" }
+```
+
+
+

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -7,6 +7,7 @@ export default {
   ],
   rules: {
     '@stencil-community/strict-boolean-conditions': 1,
+    '@stencil-community/ban-default-true': 1,
     '@stencil-community/ban-exported-const-enums': 2,
     // '@stencil-community/ban-side-effects': 2,
     '@stencil-community/strict-mutable': 2,

--- a/src/configs/strict.ts
+++ b/src/configs/strict.ts
@@ -6,6 +6,7 @@ export default {
     "plugin:@stencil-community/recommended",
   ],
   rules: {
+    '@stencil-community/ban-default-true': 2,
     '@stencil-community/strict-boolean-conditions': 2,
 
     // Resets

--- a/src/rules/ban-default-true.ts
+++ b/src/rules/ban-default-true.ts
@@ -17,7 +17,7 @@ const rule: Rule.RuleModule = {
 
     return {
       ...stencil.rules,
-      'ClassProperty': (node: any) => {
+      'PropertyDefinition': (node: any) => {
         const propDecorator = getDecorator(node, 'Prop');
         if (!(stencil.isComponent() && propDecorator)) {
           return;

--- a/src/rules/ban-default-true.ts
+++ b/src/rules/ban-default-true.ts
@@ -1,0 +1,37 @@
+import {Rule} from 'eslint';
+import {getDecorator, stencilComponentContext} from '../utils';
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'This rule catches Stencil Props defaulting to true.',
+      category: 'Possible Errors',
+      recommended: true
+    },
+    schema: [],
+    type: 'problem',
+  },
+
+  create(context): Rule.RuleListener {
+    const stencil = stencilComponentContext();
+
+    return {
+      ...stencil.rules,
+      'ClassProperty': (node: any) => {
+        const propDecorator = getDecorator(node, 'Prop');
+        if (!(stencil.isComponent() && propDecorator)) {
+          return;
+        }
+
+        if (node.value?.value === true) {
+          context.report({
+            node: node,
+            message: `Boolean properties decorated with @Prop() should default to false`
+          });
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,4 +1,5 @@
 import asyncMethods from './async-methods';
+import banDefaultTrue from './ban-default-true';
 import banPrefix from './ban-prefix';
 import classPattern from './class-pattern';
 import decoratorsContext from './decorators-context';
@@ -25,6 +26,7 @@ import dependencySuggestions from './dependency-suggestions';
 
 export default {
   'ban-side-effects': banSideEffects,
+  'ban-default-true': banDefaultTrue,
   'ban-exported-const-enums': banExportedConstEnums,
   'dependency-suggestions': dependencySuggestions,
   'strict-boolean-conditions': strictBooleanConditions,

--- a/tests/lib/rules/ban-default-true/ban-default-true.good.tsx
+++ b/tests/lib/rules/ban-default-true/ban-default-true.good.tsx
@@ -1,0 +1,11 @@
+@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  @Prop() disabled: boolean;
+  @Prop() noValidate = false;
+
+  nonProp = true;
+
+  render() {
+    return (<div>test</div>);
+  }
+}

--- a/tests/lib/rules/ban-default-true/ban-default-true.spec.ts
+++ b/tests/lib/rules/ban-default-true/ban-default-true.spec.ts
@@ -1,0 +1,29 @@
+import rule from '../../../../src/rules/ban-default-true';
+import { ruleTester } from '../rule-tester';
+import * as path from 'path';
+import * as fs from 'fs';
+
+describe('stencil rules', () => {
+  const files = {
+    good: path.resolve(__dirname, 'ban-default-true.good.tsx'),
+    wrong: path.resolve(__dirname, 'ban-default-true.wrong.tsx')
+  };
+  const validCode = fs.readFileSync(files.good, 'utf8');
+
+  ruleTester.run('ban-default-true', rule, {
+    valid: [
+      {
+        code: validCode,
+        filename: files.good
+      }
+    ],
+
+    invalid: [
+      {
+        code: fs.readFileSync(files.wrong, 'utf8'),
+        filename: files.wrong,
+        errors: 1
+      }
+    ]
+  });
+});

--- a/tests/lib/rules/ban-default-true/ban-default-true.wrong.tsx
+++ b/tests/lib/rules/ban-default-true/ban-default-true.wrong.tsx
@@ -1,0 +1,8 @@
+@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  @Prop() enabled = true;
+
+  render() {
+    return (<div>test</div>);
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
In HTML, [boolean attributes always default to `false`](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes). For example, we have the attributes `disabled` and `noValidate` instead of `enabled="false"` and `validate="false"`.

This PR adds a rule to enforce similar behavior in Stencil components.

## What is the new behavior?
Added new rule `ban-default-true` to warn about Props which default to `true`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Existing applications would need to change any Props that default to `true`.

## Testing

Added unit tests.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
