### PR TITLE
fix(lint): update scopes for all rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i --save-dev eslint @typescript-eslint/parser @typescript-eslint/eslint-plug
     "project": "./tsconfig.json"
   },
   "extends": [
-    "plugin:@stencil/recommended"
+    "plugin:@stencil-community/recommended"
   ]
 }
 ```
@@ -55,83 +55,83 @@ npm run lint
 
 ## Supported Rules
 
-- [`@stencil/async-methods`](./docs/async-methods.md)
+- [`@stencil-community/async-methods`](./docs/async-methods.md)
 
 This rule catches Stencil public methods that are not async.
 
-- [`@stencil/ban-prefix`](./docs/ban-prefix.md)
+- [`@stencil-community/ban-prefix`](./docs/ban-prefix.md)
 
 This rule catches Stencil Component banned tag name prefix.
 
-- [`@stencil/class-pattern`](./docs/class-pattern.md)
+- [`@stencil-community/class-pattern`](./docs/class-pattern.md)
 
 This rule catches Stencil Component class name not matching configurable pattern.
 
-- [`@stencil/decorators-context`](./docs/decorators-context.md)
+- [`@stencil-community/decorators-context`](./docs/decorators-context.md)
 
 This rule catches Stencil decorators in bad locations.
 
-- [`@stencil/decorators-style`](./docs/decorators-style.md)
+- [`@stencil-community/decorators-style`](./docs/decorators-style.md)
 
 This rule catches Stencil decorators style usage.
 
-- [`@stencil/element-type`](./docs/element-type.md)
+- [`@stencil-community/element-type`](./docs/element-type.md)
 
 This rule catches Stencil Element decorator have the correct type.
 
-- [`@stencil/host-data-deprecated`](./docs/host-data-deprecated.md)
+- [`@stencil-community/host-data-deprecated`](./docs/host-data-deprecated.md)
 
 This rule catches Stencil method hostData.
 
-- [`@stencil/methods-must-be-public`](./docs/methods-must-be-public.md)
+- [`@stencil-community/methods-must-be-public`](./docs/methods-must-be-public.md)
 
 This rule catches Stencil Methods marked as private or protected.
 
-- [`@stencil/no-unused-watch`](./docs/no-unused-watch.md)
+- [`@stencil-community/no-unused-watch`](./docs/no-unused-watch.md)
 
 This rule catches Stencil Watchs with non existing Props or States.
 
-- [`@stencil/own-methods-must-be-private`](./docs/own-methods-must-be-private.md)
+- [`@stencil-community/own-methods-must-be-private`](./docs/own-methods-must-be-private.md)
 
 This rule catches own class methods marked as public.
 
-- [`@stencil/own-props-must-be-private`](./docs/own-props-must-be-private.md)
+- [`@stencil-community/own-props-must-be-private`](./docs/own-props-must-be-private.md)
 
 This rule catches own class properties marked as public.
 
-- [`@stencil/prefer-vdom-listener`](./docs/prefer-vdom-listener.md)
+- [`@stencil-community/prefer-vdom-listener`](./docs/prefer-vdom-listener.md)
 
 This rule catches Stencil Listen with vdom events.
 
-- [`@stencil/props-must-be-public`](./docs/props-must-be-public.md)
+- [`@stencil-community/props-must-be-public`](./docs/props-must-be-public.md)
 
 This rule catches Stencil Props marked as private or protected.
 
-- [`@stencil/props-must-be-readonly`](./docs/props-must-be-readonly.md)
+- [`@stencil-community/props-must-be-readonly`](./docs/props-must-be-readonly.md)
 
 This rule catches Stencil Props marked as non readonly, excluding mutable ones.
 
-- [`@stencil/render-returns-host`](./docs/render-returns-host.md)
+- [`@stencil-community/render-returns-host`](./docs/render-returns-host.md)
 
 This rule catches Stencil Render returning array instead of Host tag.
 
-- [`@stencil/required-jsdoc`](./docs/required-jsdoc.md)
+- [`@stencil-community/required-jsdoc`](./docs/required-jsdoc.md)
 
 This rule catches Stencil Props, Methods and Events to define jsdoc.
 
-- [`@stencil/required-prefix`](./docs/required-prefix.md)
+- [`@stencil-community/required-prefix`](./docs/required-prefix.md)
 
 This rule catches Stencil Component required tag name prefix.
 
-- [`@stencil/reserved-member-names`](./docs/reserved-member-names.md)
+- [`@stencil-community/reserved-member-names`](./docs/reserved-member-names.md)
 
 This rule catches Stencil Prop names that share names of Global HTML Attributes.
 
-- [`@stencil/single-export`](./docs/single-export.md)
+- [`@stencil-community/single-export`](./docs/single-export.md)
 
 This rule catches modules that expose more than just the Stencil Component itself.
 
-- [`@stencil/strict-mutable`](./docs/strict-mutable.md)
+- [`@stencil-community/strict-mutable`](./docs/strict-mutable.md)
 
 This rule catches Stencil Prop marked as mutable but not changing value in code.
 
@@ -139,10 +139,10 @@ This rule catches Stencil Prop marked as mutable but not changing value in code.
 
 ```json
 {
-  "@stencil/async-methods": "error",
-  "@stencil/ban-prefix": ["error", ["stencil", "stnl", "st"]],
-  "@stencil/decorators-context": "error",
-  "@stencil/decorators-style": [
+  "@stencil-community/async-methods": "error",
+  "@stencil-community/ban-prefix": ["error", ["stencil", "stnl", "st"]],
+  "@stencil-community/decorators-context": "error",
+  "@stencil-community/decorators-style": [
     "error", {
       "prop": "inline",
       "state": "inline",
@@ -152,20 +152,20 @@ This rule catches Stencil Prop marked as mutable but not changing value in code.
       "watch": "multiline",
       "listen": "multiline"
     }],
-  "@stencil/element-type": "error",
-  "@stencil/host-data-deprecated": "error",
-  "@stencil/methods-must-be-public": "error",
-  "@stencil/no-unused-watch": "error",
-  "@stencil/own-methods-must-be-private": "error",
-  "@stencil/own-props-must-be-private": "error",
-  "@stencil/prefer-vdom-listener": "error",
-  "@stencil/props-must-be-public": "error",
-  "@stencil/props-must-be-readonly": "error",
-  "@stencil/render-returns-host": "error",
-  "@stencil/required-jsdoc": "error",
-  "@stencil/reserved-member-names": "error",
-  "@stencil/single-export": "error",
-  "@stencil/strict-mutable": "error"
+  "@stencil-community/element-type": "error",
+  "@stencil-community/host-data-deprecated": "error",
+  "@stencil-community/methods-must-be-public": "error",
+  "@stencil-community/no-unused-watch": "error",
+  "@stencil-community/own-methods-must-be-private": "error",
+  "@stencil-community/own-props-must-be-private": "error",
+  "@stencil-community/prefer-vdom-listener": "error",
+  "@stencil-community/props-must-be-public": "error",
+  "@stencil-community/props-must-be-readonly": "error",
+  "@stencil-community/render-returns-host": "error",
+  "@stencil-community/required-jsdoc": "error",
+  "@stencil-community/reserved-member-names": "error",
+  "@stencil-community/single-export": "error",
+  "@stencil-community/strict-mutable": "error"
 }
 ```
 

--- a/docs/async-methods.md
+++ b/docs/async-methods.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/async-methods": "error" }
+{ "@stencil-community/async-methods": "error" }
 ```
 
 > Fix included

--- a/docs/ban-prefix.md
+++ b/docs/ban-prefix.md
@@ -9,11 +9,11 @@ An array of `"string"`s which no Component `tag` will be allowed to use as a pre
 ### Config examples
 
 ```json
-{ "@stencil/ban-prefix": ["error", ["stencil"]] }
+{ "@stencil-community/ban-prefix": ["error", ["stencil"]] }
 ```
 
 ```json
-{ "@stencil/ban-prefix": ["error", ["stencil", "st", "stnl"]] }
+{ "@stencil-community/ban-prefix": ["error", ["stencil", "st", "stnl"]] }
 ```
 
 ## Schema

--- a/docs/class-pattern.md
+++ b/docs/class-pattern.md
@@ -12,7 +12,7 @@ An object containing:
 ### Config examples
 
 ```json
-{ "@stencil/class-pattern": ["error", { "pattern": "^(?!NoStart).*Component$", "ignoreCase": true }] }
+{ "@stencil-community/class-pattern": ["error", { "pattern": "^(?!NoStart).*Component$", "ignoreCase": true }] }
 ```
 
 ## Schema

--- a/docs/decorators-context.md
+++ b/docs/decorators-context.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/decorators-context": "error" }
+{ "@stencil-community/decorators-context": "error" }
 ```

--- a/docs/decorators-style.md
+++ b/docs/decorators-style.md
@@ -18,7 +18,7 @@ If decorators are composed (multiple decorators for a single declaration), "mult
 ### Config examples
 
 ```json
-{ "@stencil/decorators-style": ["error", { "prop": "inline", "method": "multiline" }] }
+{ "@stencil-community/decorators-style": ["error", { "prop": "inline", "method": "multiline" }] }
 ```
 
 ## Schema

--- a/docs/element-type.md
+++ b/docs/element-type.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/element-type": "error" }
+{ "@stencil-community/element-type": "error" }
 ```

--- a/docs/host-data-deprecated.md
+++ b/docs/host-data-deprecated.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/host-data-deprecated": "error" }
+{ "@stencil-community/host-data-deprecated": "error" }
 ```

--- a/docs/methods-must-be-public.md
+++ b/docs/methods-must-be-public.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/methods-must-be-public": "error" }
+{ "@stencil-community/methods-must-be-public": "error" }
 ```
 
 > Fix included

--- a/docs/no-unused-watch.md
+++ b/docs/no-unused-watch.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/no-unused-watch": "error" }
+{ "@stencil-community/no-unused-watch": "error" }
 ```

--- a/docs/own-methods-must-be-private.md
+++ b/docs/own-methods-must-be-private.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/own-methods-must-be-private": "error" }
+{ "@stencil-community/own-methods-must-be-private": "error" }
 ```
 
 > Fix included

--- a/docs/own-props-must-be-private.md
+++ b/docs/own-props-must-be-private.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/own-props-must-be-private": "error" }
+{ "@stencil-community/own-props-must-be-private": "error" }
 ```
 
 > Fix included

--- a/docs/prefer-vdom-listener.md
+++ b/docs/prefer-vdom-listener.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/prefer-vdom-listener": "error" }
+{ "@stencil-community/prefer-vdom-listener": "error" }
 ```

--- a/docs/props-must-be-public.md
+++ b/docs/props-must-be-public.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/props-must-be-public": "error" }
+{ "@stencil-community/props-must-be-public": "error" }
 ```
 
 > Fix included

--- a/docs/props-must-be-readonly.md
+++ b/docs/props-must-be-readonly.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/props-must-be-readonly": "error" }
+{ "@stencil-community/props-must-be-readonly": "error" }
 ```
 
 > Fix included

--- a/docs/render-returns-host.md
+++ b/docs/render-returns-host.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/render-returns-host": "error" }
+{ "@stencil-community/render-returns-host": "error" }
 ```

--- a/docs/required-jsdoc.md
+++ b/docs/required-jsdoc.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/required-jsdoc": "error" }
+{ "@stencil-community/required-jsdoc": "error" }
 ```

--- a/docs/required-prefix.md
+++ b/docs/required-prefix.md
@@ -9,7 +9,7 @@ An array of `"string"`s which Component `tag` will be use as a prefix.
 ### Config examples
 
 ```json
-{ "@stencil/required-prefix": ["error", ["app"]] }
+{ "@stencil-community/required-prefix": ["error", ["app"]] }
 ```
 
 ## Schema

--- a/docs/reserved-member-names.md
+++ b/docs/reserved-member-names.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/reserved-member-names": "error" }
+{ "@stencil-community/reserved-member-names": "error" }
 ```

--- a/docs/single-export.md
+++ b/docs/single-export.md
@@ -9,5 +9,5 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/single-export": "error" }
+{ "@stencil-community/single-export": "error" }
 ```

--- a/docs/strict-mutable.md
+++ b/docs/strict-mutable.md
@@ -9,7 +9,7 @@ No config is needed
 ## Usage
 
 ```json
-{ "@stencil/strict-mutable": "error" }
+{ "@stencil-community/strict-mutable": "error" }
 ```
 
 > Fix included

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -15,21 +15,21 @@ export default {
         browser: true,
       },
       plugins: [
-        '@stencil'
+        '@stencil-community'
       ],
       rules: {
-        '@stencil/async-methods': 2,
-        '@stencil/ban-prefix': [2, ['stencil', 'stnl', 'st']],
-        '@stencil/decorators-context': 2,
-        '@stencil/element-type': 2,
-        '@stencil/host-data-deprecated': 2,
-        '@stencil/methods-must-be-public': 2,
-        '@stencil/no-unused-watch': 2,
-        '@stencil/prefer-vdom-listener': 2,
-        '@stencil/props-must-be-public': 2,
-        '@stencil/render-returns-host': 2,
-        '@stencil/reserved-member-names': 2,
-        '@stencil/single-export': 2,
+        '@stencil-community/async-methods': 2,
+        '@stencil-community/ban-prefix': [2, ['stencil', 'stnl', 'st']],
+        '@stencil-community/decorators-context': 2,
+        '@stencil-community/element-type': 2,
+        '@stencil-community/host-data-deprecated': 2,
+        '@stencil-community/methods-must-be-public': 2,
+        '@stencil-community/no-unused-watch': 2,
+        '@stencil-community/prefer-vdom-listener': 2,
+        '@stencil-community/props-must-be-public': 2,
+        '@stencil-community/render-returns-host': 2,
+        '@stencil-community/reserved-member-names': 2,
+        '@stencil-community/single-export': 2,
       }
     }
   ],

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -3,14 +3,14 @@ export default {
     "react"
   ],
   extends: [
-    "plugin:@stencil/base",
+    "plugin:@stencil-community/base",
   ],
   rules: {
-    '@stencil/strict-boolean-conditions': 1,
-    '@stencil/ban-exported-const-enums': 2,
-    // '@stencil/ban-side-effects': 2,
-    '@stencil/strict-mutable': 2,
-    '@stencil/decorators-style': [
+    '@stencil-community/strict-boolean-conditions': 1,
+    '@stencil-community/ban-exported-const-enums': 2,
+    // '@stencil-community/ban-side-effects': 2,
+    '@stencil-community/strict-mutable': 2,
+    '@stencil-community/decorators-style': [
       'error', {
         prop: 'inline',
         state: 'inline',
@@ -21,10 +21,10 @@ export default {
         listen: 'multiline'
       }
     ],
-    '@stencil/own-methods-must-be-private': 1,
-    '@stencil/own-props-must-be-private': 1,
-    '@stencil/dependency-suggestions': 1,
-    '@stencil/required-jsdoc': 1,
+    '@stencil-community/own-methods-must-be-private': 1,
+    '@stencil-community/own-props-must-be-private': 1,
+    '@stencil-community/dependency-suggestions': 1,
+    '@stencil-community/required-jsdoc': 1,
     "react/jsx-no-bind": [1, {
       "ignoreRefs": true
     }]

--- a/src/configs/strict.ts
+++ b/src/configs/strict.ts
@@ -3,10 +3,10 @@ export default {
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@stencil/recommended",
+    "plugin:@stencil-community/recommended",
   ],
   rules: {
-    '@stencil/strict-boolean-conditions': 2,
+    '@stencil-community/strict-boolean-conditions': 2,
 
     // Resets
     "@typescript-eslint/camelcase": 0,


### PR DESCRIPTION
this commit fixes the scope of each rule. previously, each rule was under the `@stencil` scope when this project was being maintained by the stencil core team. the project has since begun to move to the community model, where the npm package is published under the `@stencil-community/` scope. in the original migration to the community model (fb8dab7), updating the scopes of each rule was missed. this caused lint rule lookups to fail.

by updating the scopes for each rule, the predefined configs, and the docs, rules can once again be used

# Testing:

## Setup
- Create a Stencil starter project: `npm init stencil component eslint-tst`
- Assuming NPM 7+, install the plugin `npm i --save-dev @stencil-community/eslint-plugin`
  -  (See README for npm 6 install instructions)
- Create the following `.eslintrc.json` in the root of your project
```json
{  
  "parser": "@typescript-eslint/parser",
  "parserOptions": {
    "project": "./tsconfig.json"
  },
  "extends": [
    "plugin:@stencil-community/recommended"
  ]
}
```
- Add a lint script to `package.json`:
```json
{
  "scripts": {
    ...
    "lint": "eslint src/**/*{.ts,.tsx}"
  },
...
}
```
- `npm run lint`

## Configs
The 'recommended' config was tested in the 'setup' section. The 'base' and 'strict' configs should also be tested:
### Base Config
Update your `.eslintrc.json`:
```diff
{
  "parser": "@typescript-eslint/parser",
  "parserOptions": {
    "project": "./tsconfig.json"
  },
  "extends": [
-    "plugin:@stencil-community/recommended"
+    "plugin:@stencil-community/base"
  ]
}
```
`npm run lint`

### Strict Config
Update your `.eslintrc.json`:
```diff
{
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
    "project": "./tsconfig.json"
  },
  "extends": [
-    "plugin:@stencil-community/recommended"
+    "plugin:@stencil-community/strict"
  ]
}
```
`npm run lint`

### Individual Rules
Replace your `.eslintrc.json` file with the following:
```json
{
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
        "project": "./tsconfig.json"
    },
    "plugins": ["@stencil-community"],
    "rules": {
        "@stencil-community/async-methods": 2,
        "@stencil-community/ban-exported-const-enums": 2,
        "@stencil-community/ban-prefix": [
            2,
            [
                "stencil",
                "stnl",
                "st"
            ]
        ],
        "@stencil-community/ban-side-effects": 2,
        "@stencil-community/class-pattern": ["error", { "pattern": "^(?!NoStart).*Component$", "ignoreCase": true }],
        "@stencil-community/decorators-context": 2,
        "@stencil-community/decorators-style": [
            "error",
            {
                "prop": "inline",
                "state": "inline",
                "element": "inline",
                "event": "inline",
                "method": "multiline",
                "watch": "multiline",
                "listen": "multiline"
            }
        ],
        "@stencil-community/dependency-suggestions": 2,
        "@stencil-community/element-type": 2,
        "@stencil-community/host-data-deprecated": 2,
        "@stencil-community/methods-must-be-public": 2,
        "@stencil-community/no-unused-watch": 2,
        "@stencil-community/own-methods-must-be-private": 2,
        "@stencil-community/own-props-must-be-private": 2,
        "@stencil-community/prefer-vdom-listener": 2,
        "@stencil-community/props-must-be-public": 2,
        "@stencil-community/props-must-be-readonly": 2,
        "@stencil-community/render-returns-host": 2,
        "@stencil-community/required-jsdoc": 2,
        "@stencil-community/required-prefix": ["error", ["prefix"]],
        "@stencil-community/reserved-member-names": 2,
        "@stencil-community/single-export": 2,
        "@stencil-community/strict-boolean-conditions": 1,
        "@stencil-community/strict-mutable": 2
    }
}
```
`npm run lint`
