### PR TITLE
chore: adding missing AttachInternals to list of Stencil decorators

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,7 @@ export function getType(node: any) {
   return node.typeAnnotation.typeAnnotation.typeName.name;
 }
 
-export const stencilDecorators = ['Component', 'Prop', 'State', 'Watch', 'Element', 'Method', 'Event', 'Listen'];
+export const stencilDecorators = ['Component', 'Prop', 'State', 'Watch', 'Element', 'Method', 'Event', 'Listen', 'AttachInternals'];
 
 export const stencilLifecycle = [
   'connectedCallback',


### PR DESCRIPTION
This is a pretty simple fix for this warning that will show up when using the new `formAssociated` functionality introduced in Stencil v4.5:

![image](https://github.com/stencil-community/stencil-eslint/assets/49026685/4ecf8604-8bff-4561-bd3c-bff0b4a5503d)
