### PR TITLE
fix: adding formAssociated methods to stencil lifecycle methods list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,6 +94,10 @@ export const stencilLifecycle = [
   'componentShouldUpdate',
   'componentWillUpdate',
   'componentDidUpdate',
+  'formAssociatedCallback',
+  'formDisabledCallback',
+  'formResetCallback',
+  'formStateRestoreCallback',
   'render'
 ];
 


### PR DESCRIPTION
Currently I'm getting warnings on my formAssociated methods:
<img width="826" alt="image" src="https://github.com/stencil-community/stencil-eslint/assets/49026685/65c037fa-65b2-46d4-8042-cbd532825d49">
