### PR TITLE
fix(strict-mutable): fix order assumption when checking mutable props

### DIFF
--- a/tests/lib/rules/strict-mutable/strict-mutable.good.tsx
+++ b/tests/lib/rules/strict-mutable/strict-mutable.good.tsx
@@ -10,7 +10,7 @@ export class SampleTag {
 
   private internalMethod() {
     const test = 'hi';
-    if (!this.testNotMutable) {
+    if (!this.testNotMutable || !this.testNotMutableAfterReadSite) {
       this.testMutable = 'other value';
     }
     this.testMutableAfterAssignmentSite = true;
@@ -18,6 +18,7 @@ export class SampleTag {
   }
 
   @Prop({ mutable: true }) testMutableAfterAssignmentSite?: boolean;
+  @Prop({ mutable: false }) testNotMutableAfterAccessSite?: boolean;
 
   private onClick(e: Event) {
     e.preventDefault();

--- a/tests/lib/rules/strict-mutable/strict-mutable.good.tsx
+++ b/tests/lib/rules/strict-mutable/strict-mutable.good.tsx
@@ -13,8 +13,11 @@ export class SampleTag {
     if (!this.testNotMutable) {
       this.testMutable = 'other value';
     }
+    this.testMutableAfterAssignmentSite = true;
     return this.testMutableReturn = true;
   }
+
+  @Prop({ mutable: true }) testMutableAfterAssignmentSite?: boolean;
 
   private onClick(e: Event) {
     e.preventDefault();

--- a/tests/lib/rules/strict-mutable/strict-mutable.spec.ts
+++ b/tests/lib/rules/strict-mutable/strict-mutable.spec.ts
@@ -20,7 +20,7 @@ describe('stencil rules', () => {
       {
         code: fs.readFileSync(files.wrong, 'utf8'),
         filename: files.wrong,
-        errors: 1
+        errors: 2
       }
     ]
   });

--- a/tests/lib/rules/strict-mutable/strict-mutable.wrong.tsx
+++ b/tests/lib/rules/strict-mutable/strict-mutable.wrong.tsx
@@ -9,9 +9,17 @@ export class SampleTag {
 
   private internalMethod() {
     const test = 'hi';
+
+    if (this.testMutableAfterAssignmentSite) {
+      this.testNotMutableAfterAccessSite = "not mutable";
+    }
+
     this.testMutable = 'other value';
     return 'ok';
   }
+
+  @Prop({ mutable: true }) testMutableAfterAssignmentSite?: string;
+  @Prop({ mutable: false }) testNotMutableAfterAccessSite?: string;
 
   render() {
     return (<div>test</div>);


### PR DESCRIPTION
**Related Issue:** #111

## Summary

This updates `strict-mutable` to check props at class exit.
