### PR TITLE
fix(element-type): gracefully handle explicit `any` or missing type annotations

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,7 @@ export function stencilComponentContext() {
 }
 
 export function getType(node: any) {
-  return node.typeAnnotation.typeAnnotation.typeName.name;
+  return node.typeAnnotation?.typeAnnotation?.typeName?.name;
 }
 
 export const stencilDecorators = ['Component', 'Prop', 'State', 'Watch', 'Element', 'Method', 'Event', 'Listen', 'AttachInternals'];

--- a/tests/lib/rules/element-type/element-type.explicit-any.tsx
+++ b/tests/lib/rules/element-type/element-type.explicit-any.tsx
@@ -1,0 +1,11 @@
+@Component({ tag: 'sample-tag' })
+export class TheSampleTag {
+  /**
+   * Element: is the element
+   */
+  @Element() theElement!: any;
+
+  render() {
+    return (<div>test</div>);
+  }
+}

--- a/tests/lib/rules/element-type/element-type.missing-type-annotation.tsx
+++ b/tests/lib/rules/element-type/element-type.missing-type-annotation.tsx
@@ -1,0 +1,11 @@
+@Component({ tag: 'sample-tag' })
+export class TheSampleTag {
+  /**
+   * Element: is the element
+   */
+  @Element() theElement!;
+
+  render() {
+    return (<div>test</div>);
+  }
+}

--- a/tests/lib/rules/element-type/element-type.spec.ts
+++ b/tests/lib/rules/element-type/element-type.spec.ts
@@ -6,7 +6,9 @@ import * as fs from 'fs';
 describe('stencil rules', () => {
   const files = {
     good: path.resolve(__dirname, 'element-type.good.tsx'),
-    wrong: path.resolve(__dirname, 'element-type.wrong.tsx')
+    wrong: path.resolve(__dirname, 'element-type.wrong.tsx'),
+    explicitAny: path.resolve(__dirname, 'element-type.explicit-any.tsx'),
+    missingTypeAnnotation: path.resolve(__dirname, 'element-type.missing-type-annotation.tsx'),
   };
   const validCode = fs.readFileSync(files.good, 'utf8');
 
@@ -22,6 +24,18 @@ describe('stencil rules', () => {
       {
         code: fs.readFileSync(files.wrong, 'utf8'),
         filename: files.wrong,
+        errors: 1,
+        output: validCode,
+      },
+      {
+        code: fs.readFileSync(files.explicitAny, 'utf8'),
+        filename: files.explicitAny,
+        errors: 1,
+        output: validCode,
+      },
+      {
+        code: fs.readFileSync(files.missingTypeAnnotation, 'utf8'),
+        filename: files.missingTypeAnnotation,
         errors: 1,
         output: validCode,
       }


### PR DESCRIPTION
This PR fixes #17, and an additional edge case where the `element-type` rule was throwing a runtime error if the `Element()` decorated property was explicitly typed as `any`.

The error that currently happens with the `element-type.explicit-any.tsx` test fixture:

```
    TypeError: Cannot read properties of undefined (reading 'name')
    Occurred while linting /Users/Brandon/oss/fork/stencil-eslint/tests/lib/rules/element-type/element-type.explicit-any.tsx:6
    Rule: "element-type"

      80 |
      81 | export function getType(node: any) {
    > 82 |   return node.typeAnnotation.typeAnnotation.typeName.name;
         |                                                      ^
      83 | }
      84 |
      85 | export const stencilDecorators = ['Component', 'Prop', 'State', 'Watch', 'Element', 'Method', 'Event', 'Listen', 'AttachInternals'];

      at getType (src/utils.ts:82:54)
      at PropertyDefinition > Decorator[expression.callee.name=Element] (src/rules/element-type.ts:32:34)
      at ruleErrorHandler (node_modules/eslint/lib/linter/linter.js:1050:28)
      at node_modules/eslint/lib/linter/safe-emitter.js:45:58
          at Array.forEach (<anonymous>)
      at Object.emit (node_modules/eslint/lib/linter/safe-emitter.js:45:38)
      at NodeEventGenerator.applySelector (node_modules/eslint/lib/linter/node-event-generator.js:297:26)
      at NodeEventGenerator.applySelectors (node_modules/eslint/lib/linter/node-event-generator.js:326:22)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/linter/node-event-generator.js:340:14)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:795:23)
      at node_modules/eslint/lib/linter/linter.js:1085:32
          at Array.forEach (<anonymous>)
      at runRules (node_modules/eslint/lib/linter/linter.js:1080:15)
      at Linter._verifyWithoutProcessors (node_modules/eslint/lib/linter/linter.js:1330:31)
      at Linter.verify (node_modules/eslint/lib/linter/linter.js:1428:57)
      at runRuleForItem (node_modules/eslint/lib/rule-tester/rule-tester.js:689:35)
      at testInvalidTemplate (node_modules/eslint/lib/rule-tester/rule-tester.js:803:28)
      at Object.<anonymous> (node_modules/eslint/lib/rule-tester/rule-tester.js:1042:29)
  ```
  
The error that currently happens with the `element-type.missing-type-annotation.tsx` test fixture:

```
    TypeError: Cannot read properties of undefined (reading 'typeAnnotation')
    Occurred while linting /Users/Brandon/oss/fork/stencil-eslint/tests/lib/rules/element-type/element-type.missing-type-annotation.tsx:6
    Rule: "element-type"

      80 |
      81 | export function getType(node: any) {
    > 82 |   return node.typeAnnotation.typeAnnotation.typeName.name;
         |                              ^
      83 | }
      84 |
      85 | export const stencilDecorators = ['Component', 'Prop', 'State', 'Watch', 'Element', 'Method', 'Event', 'Listen', 'AttachInternals'];

      at getType (src/utils.ts:82:30)
      at PropertyDefinition > Decorator[expression.callee.name=Element] (src/rules/element-type.ts:32:34)
      at ruleErrorHandler (node_modules/eslint/lib/linter/linter.js:1050:28)
      at node_modules/eslint/lib/linter/safe-emitter.js:45:58
          at Array.forEach (<anonymous>)
      at Object.emit (node_modules/eslint/lib/linter/safe-emitter.js:45:38)
      at NodeEventGenerator.applySelector (node_modules/eslint/lib/linter/node-event-generator.js:297:26)
      at NodeEventGenerator.applySelectors (node_modules/eslint/lib/linter/node-event-generator.js:326:22)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/linter/node-event-generator.js:340:14)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:795:23)
      at node_modules/eslint/lib/linter/linter.js:1085:32
          at Array.forEach (<anonymous>)
      at runRules (node_modules/eslint/lib/linter/linter.js:1080:15)
      at Linter._verifyWithoutProcessors (node_modules/eslint/lib/linter/linter.js:1330:31)
      at Linter.verify (node_modules/eslint/lib/linter/linter.js:1428:57)
      at runRuleForItem (node_modules/eslint/lib/rule-tester/rule-tester.js:689:35)
      at testInvalidTemplate (node_modules/eslint/lib/rule-tester/rule-tester.js:803:28)
      at Object.<anonymous> (node_modules/eslint/lib/rule-tester/rule-tester.js:1042:29)
  ```