### PR TITLE
fix: allow @Prop() to have `get()` or `set()`

### DIFF
--- a/src/rules/decorators-context.ts
+++ b/src/rules/decorators-context.ts
@@ -29,7 +29,13 @@ const rule: Rule.RuleModule = {
               decName === 'Element' ||
               decName === 'Event'
           ) {
-            if (node.parent.type !== 'PropertyDefinition') {
+            if (
+              node.parent.type !== 'PropertyDefinition' && 
+              (
+                node.parent.type === 'MethodDefinition' && 
+                ['get', 'set'].indexOf(node.parent.kind) < 0
+              )
+            ) {              
               context.report({
                 node: node,
                 message: `The @${decName} decorator can only be applied to class properties.`

--- a/src/rules/no-unused-watch.ts
+++ b/src/rules/no-unused-watch.ts
@@ -46,7 +46,9 @@ const rule: Rule.RuleModule = {
     return {
       ClassDeclaration: stencil.rules.ClassDeclaration,
       'PropertyDefinition > Decorator[expression.callee.name=Prop]': getVars,
-      'PropertyDefinition > Decorator[expression.callee.name=State]': getVars,
+      'MethodDefinition[kind=get] > Decorator[expression.callee.name=Prop]': getVars,
+      'MethodDefinition[kind=set] > Decorator[expression.callee.name=Prop]': getVars,
+      'PropertyDefinition > Decorator[expression.callee.name=State]': getVars,      
       'MethodDefinition[kind=method] > Decorator[expression.callee.name=Watch]': checkWatch,
       'ClassDeclaration:exit': (node: any) => {
         if (!stencil.isComponent()) {

--- a/tests/lib/rules/decorators-context/decorators-context.good.tsx
+++ b/tests/lib/rules/decorators-context/decorators-context.good.tsx
@@ -3,6 +3,11 @@ export class SampleTag {
 
   @Prop() test?: string;
 
+  @Prop() 
+  get testGetter() {
+    return 'getter';
+  }
+
   @Element() element!: HTMLElement;
 
   @Method()

--- a/tests/lib/rules/no-unused-watch/no-unused-watch.good.tsx
+++ b/tests/lib/rules/no-unused-watch/no-unused-watch.good.tsx
@@ -2,8 +2,14 @@
 export class SampleTag {
   @Prop() test?: string;
 
+  @Prop() 
+  get testGetter() {
+    return 'getter';
+  }
+
   @State() testState = 1;
 
+  @Watch('testGetter')
   @Watch('test')
   @Watch('testState')
   watchFn() {


### PR DESCRIPTION
as per https://github.com/ionic-team/stencil/pull/6050 Stencil now allows `@Prop()` decorated members to have `get()` or `set()` methods.
