### PR TITLE
feat: add support for eslint flat config (eslint >= 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm i --save-dev eslint @typescript-eslint/parser @typescript-eslint/eslint-plug
 
 ## Usage
 
+### Configuration (legacy: .eslintrc*)
+
 `.eslintrc.json` configuration file:
 
 ```json
@@ -30,14 +32,39 @@ npm i --save-dev eslint @typescript-eslint/parser @typescript-eslint/eslint-plug
 }
 ```
 
-Add a new `lint` script to the `package.json`:
-```json
-{
-  "scripts": {
-    "lint": "eslint src/**/*{.ts,.tsx}"
-  }
-}
+### Configuration (new: eslint.config.*)
+
+The plugin exports 3 flat configs for use with eslint >= 9:
+
+- flat.base
+- flat.recommended
+- flat.strict
+
+
+```js
+// eslint.config.js
+const stencilLint = require('@stencil-community/eslint-plugin');
+
+module.exports = [
+  ...
+  stencilLint.configs.flat.recommended,
+  ...
+];
 ```
+
+Alternatively:
+
+```js
+// eslint.config.mjs
+import stencilLint from '@stencil-community/eslint-plugin';
+
+export default [
+  ...
+  stencilLint.configs.flat.recommended,
+  ...
+];
+```
+
 
 By default, ESLint will ignore your `node_modules/` directory. Consider adding a `.eslintignore` file at the root of
 your project with any output target directories to avoid false positive errors from ESLint.

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,7 +14,8 @@ export default {
     'eslint',
     'typescript',
     'tsutils',
-    'eslint-utils'
+    'eslint-utils',
+    'eslint-plugin-react'
   ],
   output: {
     file: 'dist/index.js',

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -5,5 +5,6 @@ import strict from './strict';
 export default {
   base,
   recommended,
-  strict
+  strict,
+  flat: {},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,44 @@
  * @author Tom Chinery &lt;tom.chinery@addtoevent.co.uk&gt;
  */
 
+// @ts-expect-error - no types
+import react from 'eslint-plugin-react';
 import rules from './rules';
 import configs from './configs';
 
-export {
+const plugin = {
   rules,
   configs
 };
+
+const flatBase = {
+  plugins: { '@stencil-community': plugin },
+  rules: configs.base.overrides[0].rules,
+  languageOptions: { parserOptions: configs.base.overrides[0].parserOptions },
+}
+
+const flatRecommended = {
+  plugins: { 
+    react: react, 
+    '@stencil-community': plugin 
+  },
+  rules: configs.recommended.rules,
+  languageOptions: { parserOptions: configs.base.overrides[0].parserOptions },
+}
+
+const flatStrict = {
+  plugins: { 
+    react: react, 
+    '@stencil-community': plugin 
+  },
+  rules: configs.strict.rules,
+  languageOptions: { parserOptions: configs.base.overrides[0].parserOptions },
+}
+
+configs.flat = {
+  base: flatBase,
+  recommended: flatRecommended,
+  strict: flatStrict,
+}
+
+export default plugin;


### PR DESCRIPTION
Hi!
This just adds support for eslint 9's flat config.

I've kept the legacy configs as is and added a new flat property with base, recommended, strict objects which utilise their legacy counterparts.

I've built the project locally and have linked it / been using it with a Stencil project with eslint 9. All flat configs seem to work fine.

Closes https://github.com/stencil-community/stencil-eslint/issues/119